### PR TITLE
feat: bulk update status, order selection drawer

### DIFF
--- a/client/src/features/orders/components/bulk-action-controls.tsx
+++ b/client/src/features/orders/components/bulk-action-controls.tsx
@@ -1,4 +1,6 @@
-import { Button, Modal, Text, Group } from "@mantine/core";
+import { Button, Tooltip, Group } from "@mantine/core";
+import { DocumentArrowDownIcon } from "@heroicons/react/24/solid";
+import BulkActionsDrawer from "./bulk-actions-drawer";
 
 interface BulkActionsControlsProps {
   selectedOrders: string[];
@@ -10,42 +12,36 @@ interface BulkActionsControlsProps {
 
 const BulkActionsControls: React.FC<BulkActionsControlsProps> = ({
   selectedOrders,
-  setSelectedOrders,
   modalOpened,
   open,
   close,
 }) => {
   return (
     <>
-      <Button
-        mt="md"
-        color="red"
-        disabled={!selectedOrders.length}
-        onClick={open}
-      >
-        Bulk Cancel Orders
-      </Button>
-
-      <Modal opened={modalOpened} onClose={close} title="Confirm Bulk Action">
-        <Text>
-          Are you sure you want to cancel {selectedOrders.length} orders?
-        </Text>
-        <Group mt="md">
+      <Group align="apart" mt="md">
+        <Tooltip
+          label="Select at least one order to generate files"
+          disabled={selectedOrders.length > 0}
+        >
           <Button
-            color="red"
-            onClick={() => {
-              console.log("Cancelled orders:", selectedOrders);
-              setSelectedOrders([]);
-              close();
-            }}
+            leftSection={<DocumentArrowDownIcon className="w-5 h-5" />}
+            onClick={open}
+            disabled={selectedOrders.length === 0}
           >
-            Confirm
+            Generate Files
           </Button>
-          <Button variant="default" onClick={close}>
-            Cancel
-          </Button>
-        </Group>
-      </Modal>
+        </Tooltip>
+      </Group>
+
+      <BulkActionsDrawer
+        selectedOrders={selectedOrders}
+        setSelectedOrders={() => {}}
+        isOpen={modalOpened}
+        onClose={close}
+        onUpdateStatus={() => {}}
+        onGenerateCSV={() => {}}
+        onGeneratePDF={() => {}}
+      />
     </>
   );
 };

--- a/client/src/features/orders/components/bulk-actions-drawer.tsx
+++ b/client/src/features/orders/components/bulk-actions-drawer.tsx
@@ -1,0 +1,34 @@
+import { Drawer, Text } from "@mantine/core";
+
+interface BulkActionsDrawerProps {
+  selectedOrders: string[];
+  setSelectedOrders: React.Dispatch<React.SetStateAction<string[]>>;
+  isOpen: boolean;
+  onClose: () => void;
+  actionType: "update-status" | "generate-files";
+  onUpdateStatus: (status: string) => void;
+  onGenerateCSV: (includeItems: boolean) => void;
+  onGeneratePDF: (includeItems: boolean) => void;
+}
+
+const BulkActionsDrawer: React.FC<BulkActionsDrawerProps> = ({
+  selectedOrders,
+  isOpen,
+  onClose,
+}) => {
+  return (
+    <Drawer
+      opened={isOpen}
+      onClose={onClose}
+      title={`Bulk Actions (${selectedOrders.length} selected)`}
+      position="right"
+      size="lg"
+    >
+      <Text size="sm" mb="sm">
+        Selected Orders: {selectedOrders.length}
+      </Text>
+    </Drawer>
+  );
+};
+
+export default BulkActionsDrawer;

--- a/client/src/features/orders/components/bulk-actions-drawer.tsx
+++ b/client/src/features/orders/components/bulk-actions-drawer.tsx
@@ -1,4 +1,19 @@
-import { Drawer, Text } from "@mantine/core";
+import { useState } from "react";
+import {
+  Drawer,
+  Button,
+  Select,
+  Switch,
+  Text,
+  Group,
+  LoadingOverlay,
+  Divider,
+} from "@mantine/core";
+import { OrderStatusEnum } from "../../../schemas/order-schemas";
+import {
+  DocumentArrowDownIcon,
+  CheckCircleIcon,
+} from "@heroicons/react/24/solid";
 
 interface BulkActionsDrawerProps {
   selectedOrders: string[];
@@ -13,9 +28,41 @@ interface BulkActionsDrawerProps {
 
 const BulkActionsDrawer: React.FC<BulkActionsDrawerProps> = ({
   selectedOrders,
+  setSelectedOrders,
   isOpen,
   onClose,
+  actionType,
+  onUpdateStatus,
+  onGenerateCSV,
+  onGeneratePDF,
 }) => {
+  const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
+  const [includeOrderItems, setIncludeOrderItems] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleUpdateStatus = () => {
+    if (!selectedStatus) return;
+    setIsProcessing(true);
+    onUpdateStatus(selectedStatus);
+    setTimeout(() => {
+      setIsProcessing(false);
+      setSelectedOrders([]);
+      onClose();
+    }, 1500);
+  };
+
+  const handleGenerateCSV = () => {
+    setIsProcessing(true);
+    onGenerateCSV(includeOrderItems);
+    setTimeout(() => setIsProcessing(false), 1500);
+  };
+
+  const handleGeneratePDF = () => {
+    setIsProcessing(true);
+    onGeneratePDF(includeOrderItems);
+    setTimeout(() => setIsProcessing(false), 1500);
+  };
+
   return (
     <Drawer
       opened={isOpen}
@@ -24,9 +71,73 @@ const BulkActionsDrawer: React.FC<BulkActionsDrawerProps> = ({
       position="right"
       size="lg"
     >
+      <LoadingOverlay visible={isProcessing} />
+
       <Text size="sm" mb="sm">
         Selected Orders: {selectedOrders.length}
       </Text>
+
+      {actionType === "update-status" && (
+        <>
+          <Select
+            label="Change Order Status"
+            placeholder="Select new status"
+            data={OrderStatusEnum.options.map((status) => ({
+              value: status,
+              label: status,
+            }))}
+            value={selectedStatus}
+            onChange={(value) => setSelectedStatus(value || "")}
+            disabled={isProcessing}
+          />
+          <Button
+            mt="sm"
+            fullWidth
+            onClick={handleUpdateStatus}
+            disabled={!selectedStatus || isProcessing}
+            leftSection={<CheckCircleIcon style={{ width: 20, height: 20 }} />}
+          >
+            Update Status
+          </Button>
+        </>
+      )}
+
+      {actionType === "generate-files" && (
+        <>
+          <Switch
+            label="Include Order Items in File"
+            checked={includeOrderItems}
+            onChange={(event) =>
+              setIncludeOrderItems(event.currentTarget.checked)
+            }
+            mt="sm"
+          />
+          <Divider my="sm" />
+          <Group mt="sm">
+            <Button
+              fullWidth
+              onClick={handleGenerateCSV}
+              disabled={isProcessing}
+              leftSection={
+                <DocumentArrowDownIcon style={{ width: 20, height: 20 }} />
+              }
+            >
+              Generate CSV
+            </Button>
+            <Button
+              fullWidth
+              color="red"
+              onClick={handleGeneratePDF}
+              disabled={isProcessing}
+              leftSection={
+                <DocumentArrowDownIcon style={{ width: 20, height: 20 }} />
+              }
+            >
+              Generate PDF
+            </Button>
+          </Group>
+        </>
+      )}
     </Drawer>
   );
 };

--- a/client/src/features/orders/components/bulk-actions-drawer.tsx
+++ b/client/src/features/orders/components/bulk-actions-drawer.tsx
@@ -8,16 +8,17 @@ import {
   Group,
   LoadingOverlay,
   Divider,
+  Table,
 } from "@mantine/core";
-import { OrderStatusEnum } from "../../../schemas/order-schemas";
+import { Order, OrderStatusEnum } from "../../../schemas/order-schemas";
 import {
   DocumentArrowDownIcon,
   CheckCircleIcon,
 } from "@heroicons/react/24/solid";
 
 interface BulkActionsDrawerProps {
-  selectedOrders: string[];
-  setSelectedOrders: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedOrders: Order[];
+  setSelectedOrders: React.Dispatch<React.SetStateAction<Order[]>>;
   isOpen: boolean;
   onClose: () => void;
   actionType: "update-status" | "generate-files";
@@ -73,9 +74,27 @@ const BulkActionsDrawer: React.FC<BulkActionsDrawerProps> = ({
     >
       <LoadingOverlay visible={isProcessing} />
 
-      <Text size="sm" mb="sm">
-        Selected Orders: {selectedOrders.length}
+      <Text size="md" mt="md" mb="sm">
+        Selected Orders:
       </Text>
+      <Table striped mb="xl">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Order ID</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Total Amount</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {selectedOrders.map((order) => (
+            <Table.Tr key={order.orderId}>
+              <Table.Td>{order.orderId}</Table.Td>
+              <Table.Td>{order.orderStatus}</Table.Td>
+              <Table.Td>${order.totalAmount}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
 
       {actionType === "update-status" && (
         <>

--- a/client/src/features/orders/components/order-status-badge.tsx
+++ b/client/src/features/orders/components/order-status-badge.tsx
@@ -29,44 +29,48 @@ const OrderStatusBadge: React.FC<OrderStatusBadgeProps> = ({
   const orderStatuses =
     OrderStatusEnum.options as (typeof OrderStatusEnum._type)[];
 
-  return (
-    <Menu withinPortal>
-      <Menu.Target>
-        <Badge
-          color={statusColors[status]}
-        //   fullWidth
-          autoContrast
-          rightSection={
-            <ActionIcon size="xs" variant="transparent">
-              <ChevronDownIcon
-                width={14}
-                height={14}
-                stroke="black"
-                strokeWidth={2}
-              />
-            </ActionIcon>
-          }
-          styles={{
-            root: {
-              minWidth: 120,   
-              textAlign: 'right',
-              alignItems: 'center',
-              cursor: 'pointer',
-            },
-          }}
-        >
-          {status}
-        </Badge>
-      </Menu.Target>
-      <Menu.Dropdown>
-        {orderStatuses.map((s) => (
-          <Menu.Item key={s} onClick={() => handleStatusChange(s)}>
-            {s}
-          </Menu.Item>
-        ))}
-      </Menu.Dropdown>
-    </Menu>
-  );
-};
-
-export default OrderStatusBadge;
+    return (
+      <Menu withinPortal disabled={status === "Canceled"}>
+        <Menu.Target>
+          <Badge
+            color={statusColors[status]}
+            autoContrast
+            rightSection={
+              status !== "Canceled" && (
+                <ActionIcon size="xs" variant="transparent">
+                  <ChevronDownIcon
+                    width={14}
+                    height={14}
+                    stroke="black"
+                    strokeWidth={2}
+                  />
+                </ActionIcon>
+              )
+            }
+            styles={{
+              root: {
+                minWidth: 120,
+                textAlign: "right",
+                alignItems: "center",
+                cursor: status === "Canceled" ? "not-allowed" : "pointer",
+                opacity: status === "Canceled" ? 0.6 : 1, // Gray out if disabled
+              },
+            }}
+          >
+            {status}
+          </Badge>
+        </Menu.Target>
+        {status !== "Canceled" && (
+          <Menu.Dropdown>
+            {orderStatuses.map((s) => (
+              <Menu.Item key={s} onClick={() => handleStatusChange(s)}>
+                {s}
+              </Menu.Item>
+            ))}
+          </Menu.Dropdown>
+        )}
+      </Menu>
+    );
+  };
+  
+  export default OrderStatusBadge;

--- a/client/src/features/orders/components/orders-table-body.tsx
+++ b/client/src/features/orders/components/orders-table-body.tsx
@@ -1,11 +1,10 @@
-import { Table, Text } from "@mantine/core";
+import { Table } from "@mantine/core";
 import { SortableHeader } from "./sortable-header";
 import OrderTableRow from "./orders-table-row";
 import { Order } from "../../../schemas/order-schemas";
 
 interface OrdersTableBodyProps {
   orders: Order[];
-  total: number;
   selectedOrders: string[];
   setSelectedOrders: React.Dispatch<React.SetStateAction<string[]>>;
   sortBy: string;
@@ -15,14 +14,12 @@ interface OrdersTableBodyProps {
 
 const OrdersTableBody: React.FC<OrdersTableBodyProps> = ({
   orders,
-  total,
   selectedOrders,
   setSelectedOrders,
   sortBy,
   sortOrder,
   onSort,
 }) => {
-  // console.log(JSON.stringify(orders));
   const allSelected =
     orders.length > 0 && selectedOrders.length === orders.length;
 
@@ -36,9 +33,6 @@ const OrdersTableBody: React.FC<OrdersTableBodyProps> = ({
 
   return (
     <div>
-      <Text size="sm" mb="sm" pl="sm">
-        Showing {orders.length} of {total} orders
-      </Text>
       <Table withRowBorders withTableBorder className="orders-table">
         <Table.Thead>
           <Table.Tr>

--- a/client/src/features/orders/components/orders-table-body.tsx
+++ b/client/src/features/orders/components/orders-table-body.tsx
@@ -5,8 +5,8 @@ import { Order } from "../../../schemas/order-schemas";
 
 interface OrdersTableBodyProps {
   orders: Order[];
-  selectedOrders: string[];
-  setSelectedOrders: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedOrders: Order[];
+  setSelectedOrders: React.Dispatch<React.SetStateAction<Order[]>>; 
   sortBy: string;
   sortOrder: "asc" | "desc";
   onSort: (column: string) => void;
@@ -27,7 +27,8 @@ const OrdersTableBody: React.FC<OrdersTableBodyProps> = ({
     if (allSelected) {
       setSelectedOrders([]);
     } else {
-      setSelectedOrders(orders.map((order) => order.orderId));
+      // setSelectedOrders(orders.map((order) => order.orderId));
+      setSelectedOrders(orders);
     }
   };
 

--- a/client/src/features/orders/components/orders-table-body.tsx
+++ b/client/src/features/orders/components/orders-table-body.tsx
@@ -1,4 +1,4 @@
-import { Table } from "@mantine/core";
+import { Checkbox, Table } from "@mantine/core";
 import { SortableHeader } from "./sortable-header";
 import OrderTableRow from "./orders-table-row";
 import { Order } from "../../../schemas/order-schemas";
@@ -38,10 +38,10 @@ const OrdersTableBody: React.FC<OrdersTableBodyProps> = ({
         <Table.Thead>
           <Table.Tr>
             <Table.Th>
-              <input
-                type="checkbox"
+            <Checkbox
                 checked={allSelected}
                 onChange={toggleSelectAll}
+                size="sm"
               />
             </Table.Th>
             <SortableHeader

--- a/client/src/features/orders/components/orders-table-controls.tsx
+++ b/client/src/features/orders/components/orders-table-controls.tsx
@@ -49,16 +49,6 @@ const OrderTableControls = forwardRef<
           />
 
           <DatesProvider settings={{ consistentWeeks: true }}>
-            {/* <MonthPickerInput
-              label="Pick month"
-              placeholder="Pick month"
-              type="range"
-              clearable
-              onChange={(value) => {
-                console.log("DatePickerInput changed:", value);
-                setDateRange(value);
-              }}
-            /> */}
             <DatePickerInput
               label="Pick date range"
               placeholder="Select date range"

--- a/client/src/features/orders/components/orders-table-row.tsx
+++ b/client/src/features/orders/components/orders-table-row.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useOrderItems } from "../api/orders-queries";
-import { useMantineTheme, useMantineColorScheme } from "@mantine/core";
+import {
+  useMantineTheme,
+  useMantineColorScheme,
+  Checkbox,
+} from "@mantine/core";
 import { Table, Text, Collapse, Button, Loader } from "@mantine/core";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import OrderStatusBadge from "./order-status-badge";
@@ -47,10 +51,10 @@ const OrderTableRow: React.FC<OrderTableRowProps> = ({
         }`}
       >
         <Table.Td>
-        <input
-            type="checkbox"
+          <Checkbox
             checked={selectedOrders.some((o) => o.orderId === order.orderId)}
             onChange={toggleSelect}
+            size="sm"
           />
         </Table.Td>
         <Table.Td>

--- a/client/src/features/orders/components/orders-table-row.tsx
+++ b/client/src/features/orders/components/orders-table-row.tsx
@@ -10,8 +10,8 @@ import OrderItemsTable from "./orders-items-table";
 
 interface OrderTableRowProps {
   order: Order & { customer: string };
-  selectedOrders: string[];
-  setSelectedOrders: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedOrders: Order[];
+  setSelectedOrders: React.Dispatch<React.SetStateAction<Order[]>>;
 }
 
 const OrderTableRow: React.FC<OrderTableRowProps> = ({
@@ -28,25 +28,29 @@ const OrderTableRow: React.FC<OrderTableRowProps> = ({
   const theme = useMantineTheme();
   const { colorScheme } = useMantineColorScheme();
 
+  const toggleSelect = () => {
+    setSelectedOrders((prev) =>
+      prev.some((o) => o.orderId === order.orderId)
+        ? prev.filter((o) => o.orderId !== order.orderId)
+        : [...prev, order]
+    );
+  };
+
   return (
     <>
       <Table.Tr
         key={order.orderId}
         className={`tablerow ${
-          selectedOrders.includes(order.orderId) ? "selected" : ""
+          selectedOrders.some((o) => o.orderId === order.orderId)
+            ? "selected"
+            : ""
         }`}
       >
         <Table.Td>
-          <input
+        <input
             type="checkbox"
-            checked={selectedOrders.includes(order.orderId)}
-            onChange={() => {
-              setSelectedOrders((prev) =>
-                prev.includes(order.orderId)
-                  ? prev.filter((id) => id !== order.orderId)
-                  : [...prev, order.orderId]
-              );
-            }}
+            checked={selectedOrders.some((o) => o.orderId === order.orderId)}
+            onChange={toggleSelect}
           />
         </Table.Td>
         <Table.Td>

--- a/client/src/features/orders/components/orders-table.tsx
+++ b/client/src/features/orders/components/orders-table.tsx
@@ -1,11 +1,15 @@
 import { useState, useRef, useEffect } from "react";
-import { Text, Button, Group, Loader } from "@mantine/core";
+import { Text, Button, Group, Loader, Tooltip } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 import { useOrdersInfinite } from "../api/orders-queries";
 import OrderTableControls from "./orders-table-controls";
 import OrdersTableBody from "./orders-table-body";
-import BulkActionsControls from "./bulk-action-controls";
+import BulkActionsDrawer from "./bulk-actions-drawer";
 import { useDisclosure } from "@mantine/hooks";
+import {
+  DocumentArrowDownIcon,
+  CheckCircleIcon,
+} from "@heroicons/react/24/outline";
 
 const OrdersTable = () => {
   const [searchInput, setSearchInput] = useState("");
@@ -17,7 +21,10 @@ const OrdersTable = () => {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [limit, setLimit] = useState<number>(10);
   const [selectedOrders, setSelectedOrders] = useState<string[]>([]);
-  const [modalOpened, { open, close }] = useDisclosure(false);
+  const [bulkActionType, setBulkActionType] = useState<
+    "update-status" | "generate-files"
+  >("update-status");
+  const [bulkDrawerOpen, { open, close }] = useDisclosure(false);
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
@@ -40,8 +47,6 @@ const OrdersTable = () => {
 
   const orders = data?.pages.flatMap((page) => page.data) || [];
 
-  // When the user types (searchInput changes), ensure the search input stays focused.
-  // Not working, loses the focus after re-render. Remember to debug.
   useEffect(() => {
     if (
       searchInputRef.current &&
@@ -68,6 +73,13 @@ const OrdersTable = () => {
     });
   };
 
+  const openBulkActionsDrawer = (
+    action: "update-status" | "generate-files"
+  ) => {
+    setBulkActionType(action);
+    open();
+  };
+
   if (isLoading) return <Loader color="blue" />;
   if (error) return <Text>Error fetching orders.</Text>;
 
@@ -82,6 +94,41 @@ const OrdersTable = () => {
         limit={limit}
         onLimitChange={setLimit}
       />
+
+      <Group justify="space-between" align="center" mb="sm">
+        <Text size="sm" pl="sm">
+          Showing {orders.length} of {data?.pages[0]?.total || 0} orders
+        </Text>
+
+        <Group>
+          <Tooltip label="Select Orders to Update Order Status">
+            <Button
+              leftSection={
+                <CheckCircleIcon style={{ width: 20, height: 20 }} />
+              }
+              onClick={() => openBulkActionsDrawer("update-status")}
+              disabled={selectedOrders.length === 0}
+              variant="outline"
+            >
+              Bulk Update Status
+            </Button>
+          </Tooltip>
+
+          <Tooltip label="Select Orders to Generate Files">
+            <Button
+              leftSection={
+                <DocumentArrowDownIcon style={{ width: 20, height: 20 }} />
+              }
+              onClick={() => openBulkActionsDrawer("generate-files")}
+              disabled={selectedOrders.length === 0}
+              color="orange"
+              variant="outline"
+            >
+              Generate CSV / PDF
+            </Button>
+          </Tooltip>
+        </Group>
+      </Group>
 
       <OrdersTableBody
         orders={orders.map((o) => ({
@@ -106,12 +153,18 @@ const OrdersTable = () => {
         )}
       </Group>
 
-      <BulkActionsControls
+      <BulkActionsDrawer
         selectedOrders={selectedOrders}
         setSelectedOrders={setSelectedOrders}
-        modalOpened={modalOpened}
-        open={open}
-        close={close}
+        isOpen={bulkDrawerOpen}
+        onClose={close}
+
+        onGenerateCSV={(includeItems) =>
+          console.log("Generating CSV, Include Items:", includeItems)
+        }
+        onGeneratePDF={(includeItems) =>
+          console.log("Generating PDF, Include Items:", includeItems)
+        }
       />
     </div>
   );

--- a/client/src/features/orders/components/orders-table.tsx
+++ b/client/src/features/orders/components/orders-table.tsx
@@ -135,7 +135,7 @@ const OrdersTable = () => {
           ...o,
           items: o.items ?? [],
         }))}
-        total={data?.pages[0]?.total || 0}
+        // total={data?.pages[0]?.total || 0}
         selectedOrders={selectedOrders}
         setSelectedOrders={setSelectedOrders}
         sortBy={sortBy}
@@ -158,7 +158,8 @@ const OrdersTable = () => {
         setSelectedOrders={setSelectedOrders}
         isOpen={bulkDrawerOpen}
         onClose={close}
-
+        actionType={bulkActionType}
+        onUpdateStatus={(status) => console.log("Updating status to:", status)}
         onGenerateCSV={(includeItems) =>
           console.log("Generating CSV, Include Items:", includeItems)
         }

--- a/client/src/features/orders/components/orders-table.tsx
+++ b/client/src/features/orders/components/orders-table.tsx
@@ -10,6 +10,7 @@ import {
   DocumentArrowDownIcon,
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
+import { Order } from "../../../schemas/order-schemas";
 
 const OrdersTable = () => {
   const [searchInput, setSearchInput] = useState("");
@@ -20,7 +21,8 @@ const OrdersTable = () => {
   const [sortBy, setSortBy] = useState<string>("orderDate");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [limit, setLimit] = useState<number>(10);
-  const [selectedOrders, setSelectedOrders] = useState<string[]>([]);
+  // const [selectedOrders, setSelectedOrders] = useState<string[]>([]);
+  const [selectedOrders, setSelectedOrders] = useState<Order[]>([]);
   const [bulkActionType, setBulkActionType] = useState<
     "update-status" | "generate-files"
   >("update-status");

--- a/client/src/features/orders/pages/orders-page.tsx
+++ b/client/src/features/orders/pages/orders-page.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { Tabs, Group, Title } from "@mantine/core";
 import OrdersTable from "../components/orders-table";
-import OrdersSummary from "../components/orders-summary";
+// import OrdersSummary from "../components/orders-summary";
 
 const OrdersPage = () => {
   const [activeTab, setActiveTab] = useState<string | null>("all");
@@ -17,14 +17,14 @@ const OrdersPage = () => {
       <Tabs value={activeTab} onChange={setActiveTab}>
         <Tabs.List>
           <Tabs.Tab value="all">Order Management</Tabs.Tab>
-          <Tabs.Tab value="summary">Orders Insights</Tabs.Tab>
+          {/* <Tabs.Tab value="summary">Orders Insights</Tabs.Tab> */}
         </Tabs.List>
         <Tabs.Panel value="all">
           <OrdersTable />
         </Tabs.Panel>
-        <Tabs.Panel value="summary">
+        {/* <Tabs.Panel value="summary">
           <OrdersSummary />
-        </Tabs.Panel>
+        </Tabs.Panel> */}
       </Tabs>
     </div>
   );

--- a/client/src/pages/welcome.tsx
+++ b/client/src/pages/welcome.tsx
@@ -86,9 +86,18 @@ import {
           <div>
             <Title order={4}>Orders</Title>
             <Text size="sm">Backend: Node.js. Manage customer orders.</Text>
-            <Button variant="light" disabled style={{ margin: "0.5rem" }}>
-              Orders Coming Soon
-            </Button>
+            <Link
+              to="/orders"
+              style={{
+                textDecoration: "none",
+                marginTop: "0.5rem",
+                display: "inline-block",
+              }}
+            >
+              <Button variant="light" style={{ margin: "0.5rem" }}>
+                Go to Orders
+              </Button>
+            </Link>
           </div>
 
           <div>

--- a/client/src/schemas/order-schemas.ts
+++ b/client/src/schemas/order-schemas.ts
@@ -7,7 +7,7 @@ export const OrderStatusEnum = z.enum(["Pending", "Processing", "Completed", "Ca
 export const OrderSchema = z.object({
   orderId: z.string().uuid(),
   customerId: z.string().uuid(),
-  customer: z.string(),
+  // customer: z.string().optional(),
   totalAmount: z.number().nonnegative(), 
   orderStatus: OrderStatusEnum,
   orderDate: z.date(),

--- a/client/src/schemas/order-schemas.ts
+++ b/client/src/schemas/order-schemas.ts
@@ -7,7 +7,7 @@ export const OrderStatusEnum = z.enum(["Pending", "Processing", "Completed", "Ca
 export const OrderSchema = z.object({
   orderId: z.string().uuid(),
   customerId: z.string().uuid(),
-  // customer: z.string().optional(),
+  customer: z.string().optional(),
   totalAmount: z.number().nonnegative(), 
   orderStatus: OrderStatusEnum,
   orderDate: z.date(),

--- a/crm-app.code-workspace
+++ b/crm-app.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "client"
+		}
+	]
+}

--- a/server/src/api/orders/order-controller.ts
+++ b/server/src/api/orders/order-controller.ts
@@ -21,20 +21,22 @@ export const listOrders = async (
   }
 };
 
-export const getOrdersSummary = async (_req: Request, res: Response) => {
-  return res.json({
-    totalOrders: 250,
-    totalRevenue: 153928.5,
-    ordersPerMonth: [
-      { month: "January", count: 50, revenue: 30000.0 },
-      { month: "December", count: 40, revenue: 25000.0 },
-    ],
-    mostOrderedProducts: [
-      { productId: "123", name: "Laptop", totalSold: 150 },
-      { productId: "456", name: "Phone", totalSold: 100 },
-    ],
-  });
-};
+// placeholder json data, feature pending now
+// maybe make statics for order route or dashboard
+// export const getOrdersSummary = async (_req: Request, res: Response) => {
+//   return res.json({
+//     totalOrders: 250,
+//     totalRevenue: 153928.5,
+//     ordersPerMonth: [
+//       { month: "January", count: 50, revenue: 30000.0 },
+//       { month: "December", count: 40, revenue: 25000.0 },
+//     ],
+//     mostOrderedProducts: [
+//       { productId: "123", name: "Laptop", totalSold: 150 },
+//       { productId: "456", name: "Phone", totalSold: 100 },
+//     ],
+//   });
+// };
 
 export const getOrderDetails = async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/server/src/api/orders/order-routes.ts
+++ b/server/src/api/orders/order-routes.ts
@@ -19,12 +19,12 @@ orderRoutes.get(
 );
 
 // Orders highlight summary
-orderRoutes.get(
-  "/summary",
-  authenticateJWT,
-  validateQuery(OrderQuerySchema),
-  orderController.getOrdersSummary
-);
+// orderRoutes.get(
+//   "/summary",
+//   authenticateJWT,
+//   validateQuery(OrderQuerySchema),
+//   orderController.getOrdersSummary
+// );
 
 orderRoutes.get(
   "/:id",

--- a/server/src/schemas/order-schemas.ts
+++ b/server/src/schemas/order-schemas.ts
@@ -1,5 +1,5 @@
 // shared/schemas/order-schemas.ts
-import { optional, z } from "zod";
+import { z } from "zod";
 
 export const OrderStatusEnum = z.enum(["Pending", "Processing", "Completed", "Canceled"]);
 

--- a/server/src/schemas/order-schemas.ts
+++ b/server/src/schemas/order-schemas.ts
@@ -1,5 +1,5 @@
 // shared/schemas/order-schemas.ts
-import { z } from "zod";
+import { optional, z } from "zod";
 
 export const OrderStatusEnum = z.enum(["Pending", "Processing", "Completed", "Canceled"]);
 
@@ -7,6 +7,7 @@ export const OrderStatusEnum = z.enum(["Pending", "Processing", "Completed", "Ca
 export const OrderSchema = z.object({
   orderId: z.string().uuid(),
   customerId: z.string().uuid(),
+  // customer: z.string().optional(),
   totalAmount: z.number().nonnegative(),  
   orderStatus: OrderStatusEnum,
   orderDate: z.date(),
@@ -17,14 +18,6 @@ export const OrderSchema = z.object({
 export const UpdateOrderStatusSchema = z.object({
   orderStatus: OrderStatusEnum,
 });
-
-
-// export const PaginatedOrdersSchema = z.object({
-//   orders: z.array(OrderSchema),
-//   total: z.number().nonnegative(),
-//   page: z.number().min(1),
-//   limit: z.number().positive(),
-// });
 
 export const CustomerOrderIdSchema = z.object({
   orderId: z.string().uuid(),

--- a/server/src/schemas/order-schemas.ts
+++ b/server/src/schemas/order-schemas.ts
@@ -7,7 +7,7 @@ export const OrderStatusEnum = z.enum(["Pending", "Processing", "Completed", "Ca
 export const OrderSchema = z.object({
   orderId: z.string().uuid(),
   customerId: z.string().uuid(),
-  // customer: z.string().optional(),
+  customer: z.string().optional(),
   totalAmount: z.number().nonnegative(),  
   orderStatus: OrderStatusEnum,
   orderDate: z.date(),


### PR DESCRIPTION
- Implemented a bulk actions drawer that displays selected orders.
- Orders with status `"Canceled"` can still be selected for reports but cannot be updated.
- Users can now bulk update order statuses or generate reports from the drawer.
